### PR TITLE
Don't have a different name and repository name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-recursionhelper",
+  "name": "angular-recursion",
   "main": "angular-recursion.js",
   "version": "1.0.3",
   "homepage": "https://github.com/marklagendijk/angular-recursion",


### PR DESCRIPTION
This confounds a number of build tools that rely on the "name" field in bower.json being identical to the repository name.
