### PR TITLE
Added compatibility with use of transclude in directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ angular.module('myModule', ['RecursionHelper']).directive("tree", function(Recur
                     '<tree family="child"></tree>' +
                 '</li>' +
             '</ul>',
-        compile: function(element) {
+        compile: function(element, attr, transclude) {
             return RecursionHelper.compile(element, function(scope, iElement, iAttrs, controller, transcludeFn){
                 // Define your normal link function here.
                 // Alternative: instead of passing a function,
                 // you can also pass an object with 
                 // a 'pre'- and 'post'-link function.
-            });
+            },transclude);
         }
     };
 });

--- a/angular-recursion.js
+++ b/angular-recursion.js
@@ -11,7 +11,7 @@ angular.module('RecursionHelper', []).factory('RecursionHelper', ['$compile', fu
 		 * @param [link] A post-link function, or an object with function(s) registered via pre and post properties.
 		 * @returns An object containing the linking functions.
 		 */
-		compile: function(element, link){
+		compile: function(element, link, transclude){
 			// Normalize the link parameter
 			if(angular.isFunction(link)){
 				link = { post: link };
@@ -28,7 +28,7 @@ angular.module('RecursionHelper', []).factory('RecursionHelper', ['$compile', fu
 				post: function(scope, element){
 					// Compile the contents
 					if(!compiledContents){
-						compiledContents = $compile(contents);
+						compiledContents = $compile(contents,transclude);
 					}
 					// Re-add the compiled contents to the element
 					compiledContents(scope, function(clone){


### PR DESCRIPTION
The service as it is doesn't work with ng-transclude (for directives with transclude:true), it causes an "ng-transclude orphan" error. This fixes it.
